### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@ This library is designed to be used with NSIS (Unicode version). It provides the
 OBSInstallerUtils::IsProcessRunning
 OBSInstallerUtils::IsDLLLoaded
 OBSInstallerUtils::AddInUseFileCheck
+OBSInstallerUtils::ResetInUseFileChecks
 OBSInstallerUtils::GetAppNameForInUseFiles
 OBSInstallerUtils::KillProcess
+OBSInstallerUtils::AddAllApplicationPackages
 ```
 
 AddInUseFileCheck expects a full path. Can be called multiple times. Afterwards, call GetAppNameForInUseFiles and $R0 will be a nicely formatted list of applications that are using the specified files.
@@ -14,5 +16,16 @@ AddInUseFileCheck expects a full path. Can be called multiple times. Afterwards,
 KillProcess takes a substring match on the full path.
 
 Other functions sets $R0 to 1 if true.
+
+Build the .dll with: 
+```
+git clone https://github.com/notr1ch/OBSInstallerUtils.git
+cd OBSInstallerUtils
+mkdir build
+cd build
+cmake -DCMAKE_GENERATOR_PLATFORM="Win32" ..
+cmake --build . --config Release
+```
+
 
 Example usage: https://github.com/jp9000/obs-studio/blob/master/UI/installer/mp-installer.nsi


### PR DESCRIPTION
When building the DLL with VS2019 without specifying the generator platform, VS builds a 64 bit DLL which does not work with NSIS. To prevent others from running into this issue, this PR adds the complete build instructions to the README.